### PR TITLE
fix: quickstart environment should not recreate if it exists

### DIFF
--- a/quickstart/run-zato-ansible.sh
+++ b/quickstart/run-zato-ansible.sh
@@ -26,6 +26,7 @@ env_keys = [
     'Zato_IP_Address',
     'Zato_Host_Dashboard_Port',
     'Zato_Host_Server_Port',
+    'Zato_Host_Server_Num',
     'Zato_Host_LB_Port',
     'Zato_Host_Database_Port',
     'Zato_Host_SSH_Port',

--- a/zato-ansible/quickstart/zato-quickstart-02.yaml
+++ b/zato-ansible/quickstart/zato-quickstart-02.yaml
@@ -305,6 +305,7 @@
         --odb-user {{ zato_db_username_main }} \
         --odb-password '{{ zato_db_password_main }}' \
         --cluster-name '{{ zato_cluster_name }}' \
+        --skip-if-exists \
         --verbose
 
 - name: Enable Redis (02)

--- a/zato-ansible/quickstart/zato-quickstart.yaml
+++ b/zato-ansible/quickstart/zato-quickstart.yaml
@@ -10,10 +10,10 @@
 
     zato_env_path: "/opt/zato/env/qs-1"
 
-    zato_db_main: "zato_db_main1"
+    zato_db_main: "{{ Zato_ODB_Name | default('zato_db_main1') }}"
     zato_db_pubsub: "zato_db_pubsub1"
 
-    zato_db_username_main: "zato_user_main1"
+    zato_db_username_main: "{{ Zato_ODB_Username | default('zato_user_main1') }}"
     zato_db_username_pubsub: "zato_user_pubsub1"
 
     pg_conf_path: "/etc/postgresql/{{ pg_version }}/main/postgresql.conf"


### PR DESCRIPTION
fix: ODB database name and username are ignored on ENV variables
fix: quickstart environment should not recreate if it exists